### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A more up-to-date approach to this **_scrolling watchers_** stuff. Slightly insp
 ## How to use it?
 ##### &#8594; CDN Hosted - [jsDelivr](http://www.jsdelivr.com/projects/scroll-watcher)
 ```HTML
-<script src="//cdn.jsdelivr.net/scroll-watcher/latest/scroll-watcher.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/scroll-watcher@latest/dist/scroll-watcher.min.js"></script>
 ```
 ##### &#8594; Self hosted
 Download [latest release](https://github.com/jonataswalker/scroll-watcher/releases/latest).


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/scroll-watcher.

Feel free to ping me if you have any questions regarding this change.